### PR TITLE
Proposal Rule 214

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,3 +6,6 @@
 
 - title: Minutes
   link: /minutes
+
+- title: Players
+  link: /players

--- a/_data/players.yml
+++ b/_data/players.yml
@@ -1,0 +1,27 @@
+- name: Mikael Vejdemo-Johansson
+  group: teachers
+  points: 10
+- name: Jonathan Hanon
+  group: teachers
+  points: 0
+- name: Bilal Abdulrahman
+  group: students
+  points: 0
+- name: Mark Chrem
+  group: students
+  points: 0
+- name: Zhijuan Jin
+  group: students
+  points: 0
+- name: Edward Miller
+  group: students
+  points: 0
+- name: Sreehari Kalloormana
+  group: students
+  points: 0
+- name: Joshua Rollins
+  group: students
+  points: 0
+- name: Rose Wong
+  group: students
+  points: 0

--- a/players.md
+++ b/players.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Players
+---
+
+Here is the current state of play in our ongoing game of Nomic:
+
+<table>
+<thead>
+ <tr>
+  <th>Name</th>
+  <th>Group</th>
+  <th>Points</th>
+ </tr>
+</thead>
+<tbody>
+{% assign toplist = site.data.players | sort: "points" | reverse %}
+{% for player in toplist %}
+ <tr>
+  <td>{{ player.name }}</td>
+  <td>{{ player.group }}</td>
+  <td>{{ player.points }}</td>
+ </tr>
+{% endfor %}
+</tbody>
+</table>


### PR DESCRIPTION
As a reward/incentive for accumulating points quickly/playing the game well, the first player to come within 10 points of winning the game is allowed to decree one mutable rule which will automatically be passed without a vote, and only a unanimous vote declaring this rule 'unreasonable' can repeal this rule once decreed. A simple majority is not enough, only unanimous votes are valid. However, if this rule is considered 'unreasonable' by unanimous vote, the winner loses 10 points. The passing of this rule does not earn pointsfor the player submitting the rule. 

The rule can overrule previous mutable rules, but cannot overrule any immutable rules, so in cases of conflicts between rules, the immutable rules still take precedence before the mutable rule decreed by the player, but the player's decree can take precedence over other mutable rules. If the rule does come into conflict with an immutable rule, it will be decreed 'unreasonable' by default, and the player will lose 10 points as if overruled by a unanimous vote. In the event of ties, and multiple players reach 10 points of winning the game at the same time,  each player is allowed to decree their own mutable rule that will be automatically passed  except by a unanimous votes, but is also subject to the same penalty of 10 points if the rule is considered 'unreasonable' by a unanimous vote.

 Lastly, if one or more players first reaching the threshold for the allowance of a decree of a mutable rule, chooses not to exercise this privilege, the player(s) does not risk a unanimous vote against and thus does not risk a loss of 10 points. This rule only takes effect for the first player(s) reaching the 10 points of winning the game threshold; it does not apply to any other players that reach the threshold after the first player(s) reach it,  regardless of whether the mutable rules decreed are considered 'unreasonable' or not and this is in effect for the duration of the game.